### PR TITLE
Fix modules caching issue in tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,4 +166,4 @@ jobs:
       #- name: install pytest dependencies
       #  run: pip install -r tests/requirements.txt
       - name: run pytest
-        run: pytest -v -s
+        run: pytest -v

--- a/examples/robot_bodybrain_ea/__init__.py
+++ b/examples/robot_bodybrain_ea/__init__.py
@@ -1,0 +1,1 @@
+"""Example evolving a modular robot brain and body with a simple evolutionary algoritm."""

--- a/examples/robot_bodybrain_ea/individual.py
+++ b/examples/robot_bodybrain_ea/individual.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from genotype import Genotype
+from .genotype import Genotype
 
 
 @dataclass

--- a/examples/robot_bodybrain_ea/main.py
+++ b/examples/robot_bodybrain_ea/main.py
@@ -25,9 +25,9 @@ from types import ModuleType
 import multineat
 import numpy as np
 import numpy.typing as npt
-from evaluator import Evaluator
-from genotype import Genotype
-from individual import Individual
+from .evaluator import Evaluator
+from .genotype import Genotype
+from .individual import Individual
 from revolve2.ci_group.logging import setup_logging
 from revolve2.ci_group.rng import make_rng_time_seed
 from revolve2.experimentation.optimization.ea import population_management, selection

--- a/examples/robot_bodybrain_ea/main.py
+++ b/examples/robot_bodybrain_ea/main.py
@@ -25,12 +25,13 @@ from types import ModuleType
 import multineat
 import numpy as np
 import numpy.typing as npt
-from .evaluator import Evaluator
-from .genotype import Genotype
-from .individual import Individual
 from revolve2.ci_group.logging import setup_logging
 from revolve2.ci_group.rng import make_rng_time_seed
 from revolve2.experimentation.optimization.ea import population_management, selection
+
+from .evaluator import Evaluator
+from .genotype import Genotype
+from .individual import Individual
 
 
 def select_parents(

--- a/examples/robot_brain_cmaes/__init__.py
+++ b/examples/robot_brain_cmaes/__init__.py
@@ -1,0 +1,1 @@
+"""Example optimizing the brain of a given robot body with the CMA-ES algorithm."""

--- a/examples/robot_brain_cmaes/main.py
+++ b/examples/robot_brain_cmaes/main.py
@@ -15,12 +15,13 @@ import logging
 from types import ModuleType
 
 import cma
-from .evaluator import Evaluator
 from revolve2.ci_group.logging import setup_logging
 from revolve2.ci_group.rng import seed_from_time
 from revolve2.modular_robot.brains import (
     body_to_actor_and_cpg_network_structure_neighbour,
 )
+
+from .evaluator import Evaluator
 
 
 def main() -> None:

--- a/examples/robot_brain_cmaes/main.py
+++ b/examples/robot_brain_cmaes/main.py
@@ -15,7 +15,7 @@ import logging
 from types import ModuleType
 
 import cma
-from evaluator import Evaluator
+from .evaluator import Evaluator
 from revolve2.ci_group.logging import setup_logging
 from revolve2.ci_group.rng import seed_from_time
 from revolve2.modular_robot.brains import (
@@ -83,7 +83,7 @@ def get_config() -> ModuleType:
 
     :returns: Config object for experiment.
     """
-    import config
+    from . import config
 
     return config
 

--- a/examples/robot_brain_cmaes/rerun.py
+++ b/examples/robot_brain_cmaes/rerun.py
@@ -1,6 +1,6 @@
 """Rerun a robot with given body and parameters."""
 
-import config
+from .main import get_config
 import numpy as np
 from evaluator import Evaluator
 from revolve2.ci_group.logging import setup_logging
@@ -32,6 +32,7 @@ PARAMS = np.array(
 def main() -> None:
     """Perform the rerun."""
     setup_logging()
+    config = get_config()
 
     _, cpg_network_structure = body_to_actor_and_cpg_network_structure_neighbour(
         config.BODY

--- a/examples/robot_brain_cmaes/rerun.py
+++ b/examples/robot_brain_cmaes/rerun.py
@@ -1,12 +1,13 @@
 """Rerun a robot with given body and parameters."""
 
-from .main import get_config
 import numpy as np
 from evaluator import Evaluator
 from revolve2.ci_group.logging import setup_logging
 from revolve2.modular_robot.brains import (
     body_to_actor_and_cpg_network_structure_neighbour,
 )
+
+from .main import get_config
 
 # These are set of parameters that we optimized using CMA-ES.
 # You can copy your own parameters from the optimization output log.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def custom_path(request, change_cwd: bool = False):
             # Restore the original working directory when the test is done
             os.chdir(original_cwd)
             print(f"restored cwd to '{os.getcwd()}'")
-        #sys.path.remove(desired_cwd)
+        # sys.path.remove(desired_cwd)
         sys.path = orig_paths.copy()
         assert os.getcwd() == original_cwd
     else:

--- a/tests/examples/test_robot_bodybrain_ea.py
+++ b/tests/examples/test_robot_bodybrain_ea.py
@@ -21,8 +21,7 @@ def mock_config():
     return config
 
 
-@pytest.mark.path(EXP_DIR)
-def test_experiment_can_complete(custom_path, mocker):
+def test_experiment_can_complete(mocker):
     """Test that main.py can complete (without crashing)."""
     # override default config (to reduce number of generations)
     mocker.patch(

--- a/tests/examples/test_robot_brain_cmaes.py
+++ b/tests/examples/test_robot_brain_cmaes.py
@@ -19,8 +19,7 @@ def mock_config():
     return config
 
 
-@pytest.mark.path(EXP_DIR)
-def test_experiment_can_complete(custom_path, mocker):
+def test_experiment_can_complete(mocker):
     """Test that main.py can complete (without crashing)."""
 
     # override default config (to reduce number of generations)


### PR DESCRIPTION
Converts the tested examples to proper python packages (add __init__.py and uses relative imports) to address the modules caching problem when running unit tests.